### PR TITLE
fix path and file extension to upper 

### DIFF
--- a/azure dark/example.py
+++ b/azure dark/example.py
@@ -16,7 +16,7 @@ y_cordinate = int((screen_height/2) - (window_height/2))
 root.geometry("{}x{}+{}+{}".format(window_width, window_height, x_cordinate, y_cordinate))
 
 style = ttk.Style(root)
-root.tk.call('source', 'azure.tcl')
+root.tk.call('source', 'azure dark.tcl')
 style.theme_use('azure')
 
 options = ['', 'OptionMenu', 'Value 1', 'Value 2']

--- a/dark_theme.py
+++ b/dark_theme.py
@@ -18,7 +18,7 @@ def main_window():
     root = tk.Tk()
     root.title("My App")
     root.resizable(False, False)
-    img = tk.PhotoImage(file="001.png")
+    img = tk.PhotoImage(file="001.PNG")
 
     style = darkstyle(root)
 


### PR DESCRIPTION
this fixes:
1. path in example.py
2. file extension png to PNG to allow examples to run on case sensitive file systems (linux)